### PR TITLE
Jenny/demo edits

### DIFF
--- a/components/ColumnNameNode.js
+++ b/components/ColumnNameNode.js
@@ -63,7 +63,10 @@ const ColumnNameNode = ({ data }) => {
       const selectedTable = tables.filter(
         (table) => table.name === data.parent
       )[0];
-      if (
+      if (editedLabel === data.label) {
+        setIsEditing(false);
+      }
+      else if (
         selectedTable.columns.includes(editedLabel) ||
         editedLabel.match(/[^A-Za-z0-9_]/g)
         || editedLabel.length === 0

--- a/components/MigrationLog.js
+++ b/components/MigrationLog.js
@@ -5,7 +5,7 @@ import useStore from './store';
 export default function MigrationLog() {
   const queries = useStore((state) => state.queries);
   const logs = queries.map((string) =>
-    _jsx(Typography, { variant: 'h6', sx: { ml: 3 }, children: string }) //could change to div
+    _jsx(Typography, { variant: 'body2', sx: { ml: 3, fontFamily: 'Fira Mono, monospace' }, children: string }) //could change to div
   );
-  return _jsx(_Fragment, { children: logs });
+  return _jsx(_Fragment, { children: logs, className: 'migration-log' });
 }

--- a/components/TableHeader.js
+++ b/components/TableHeader.js
@@ -93,7 +93,10 @@ const TableHeader = ({ data }) => {
   const handleEditSubmit = () =>
     __awaiter(void 0, void 0, void 0, function* () {
       const tableNames = tables.map((table) => table.name);
-      if (
+      if (editedLabel === data.label) {
+        setIsEditing(false);
+      }
+      else if (
         tableNames.includes(editedLabel) ||
         editedLabel.match(/[^A-Za-z0-9_]/g)
       ) {

--- a/components/logo.js
+++ b/components/logo.js
@@ -96,7 +96,7 @@ const Logo = () => {
         <div
           id="logo-text"
           className="site-title-text"
-          style={{ fontSize: '28px', color: '#646cff' }}
+          style={{ fontSize: '28px', color: '#646cff', fontFamily: 'Fira mono, monospace' }}
         >
           SQL<span style={{ color: '#e92a67' }}>ens</span>
         </div>

--- a/css/logo.scss
+++ b/css/logo.scss
@@ -1,6 +1,6 @@
-@use "sass:math";
+@import url('https://fonts.googleapis.com/css2?family=Fira+Mono:wght@400;500;700&display=swap');
 
-// @import url('https://fonts.googleapis.com/css2?family=Fira+Mono:wght@400;500;700&display=swap');
+@use "sass:math";
 
 $ff: 'Fira Mono', monospace;
 $slate: #e92a67;
@@ -11,6 +11,7 @@ $blue: #646cff;
 }
 
 body {
+  // font-family: 'Fira Mono', monospace;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -19,9 +20,9 @@ body {
 }
 
 .logo-container {
-  display: flex; 
-  align-items: center; 
-  margin-left: rem(0); 
+  display: flex;
+  align-items: center;
+  margin-left: rem(0);
 }
 
 .site-logo {
@@ -58,10 +59,10 @@ body {
   }
 
 .site-title-text {
-//   padding: rem(1); 
+//   padding: rem(1);
   color: $slate;
   font-size: rem(20);
-  font-weight: 500; 
+  font-weight: 500;
 
   span {
     font-family: $ff;

--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -49,11 +49,15 @@
   place-items: center;
 } */
 
+/* .migration-log {
+  font-family: 'Fira Mono', monospace;
+} */
 .flow-container {
   display: flex;
   width: 100vw;
   height: 60vh;
-  margin: 15px;
+  margin: 15px 0px;
+
 }
 
 .column-name-node {

--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -1,8 +1,9 @@
+@import url('https://fonts.googleapis.com/css2?family=Fira+Mono:wght@400;500;700&display=swap');
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
-@import url('https://fonts.googleapis.com/css2?family=Fira+Mono:wght@400;500;700&display=swap');
+
 
 @layer base {
   html,


### PR DESCRIPTION
## Description:
This pull request fixes logic in the demo to allow for users to save an unchanged table or column label without error alerts. It also changes the font of the migration logs and SQLens logos to be Fira Mono.
## Changes Proposed:
- User can save table name as the same name
- User can save column name as the same name
- Migration log font to be Fira Mono and font size to be smaller (MUI Typography body2)
- Logo for SQLens (top right of all pages) to be Fira Mono
## Additional Notes:
None
## Testing Strategy:
Local testing performed successfully in dev mode of NextJS
## Checklist:
[x] Users can save an unchanged table or column label without error alerts
[x] Logo font of launch page matches logo font of app
[x] Logo of demo migration log matches demo flow
## Reviewer Request:
Kindly review the proposed test suite for route integration and provide feedback for any improvements or suggestions.
## Contributors
@margarethatch
@jennyouk
@JarodCrawford
@alexpalazzo